### PR TITLE
Support for tinygo wasi target

### DIFF
--- a/wasm_imports.go
+++ b/wasm_imports.go
@@ -2,42 +2,33 @@
 
 package actor
 
-//go:wasm-module wasmbus
-//go:export __guest_request
+//go:wasmimport wasmbus __guest_request
 func guestRequest(operationPtr uintptr, payloadPtr uintptr)
 
-//go:wasm-module wasmbus
-//go:export __guest_response
+//go:wasmimport wasmbus __guest_response
 func guestResponse(ptr uintptr, len uint32) //nolint
 
-//go:wasm-module wasmbus
-//go:export __guest_error
+//go:wasmimport wasmbus __guest_error
 func guestError(ptr uintptr, len uint32)
 
-//go:wasm-module wasmbus
-//go:export __host_call
+//go:wasmimport wasmbus __host_call
 func hostCall(
 	bindingPtr uintptr, bindingLen uint32,
 	namespacePtr uintptr, namespaceLen uint32,
 	operationPtr uintptr, operationLen uint32,
 	payloadPtr uintptr, payloadLen uint32) bool
 
-//go:wasm-module wasmbus
-//go:export __host_response_len
+//go:wasmimport wasmbus __host_response_len
 func hostResponseLen() uint32
 
-//go:wasm-module wasmbus
-//go:export __host_response
+//go:wasmimport wasmbus __host_response
 func hostResponse(ptr uintptr)
 
-//go:wasm-module wasmbus
-//go:export __host_error_len
+//go:wasmimport wasmbus __host_error_len
 func hostErrorLen() uint32
 
-//go:wasm-module wasmbus
-//go:export __host_error
+//go:wasmimport wasmbus __host_error
 func hostError(ptr uintptr)
 
-//go:wasm-module wasmbus
-//go:export __console_log
+//go:wasmimport wasmbus __console_log
 func consoleLog(str uintptr, strLen uint32)

--- a/wasm_imports.go
+++ b/wasm_imports.go
@@ -1,3 +1,5 @@
+//go:build tinygo.wasm
+
 package actor
 
 //go:wasm-module wasmbus


### PR DESCRIPTION
## Feature or Problem
This will allow for the wasi target in tinygo to be used

This also updates the go tag for importing wasm per [here](https://github.com/tinygo-org/tinygo/pull/3165)

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows
